### PR TITLE
fix: colkind uses BBoxMode (#12)

### DIFF
--- a/ExportToGMS1Project.csx
+++ b/ExportToGMS1Project.csx
@@ -101,7 +101,7 @@ void ExportSprite(UndertaleSprite sprite)
             new XElement("type", "0"),
             new XElement("xorig", sprite.OriginX.ToString()),
             new XElement("yorigin", sprite.OriginY.ToString()),
-            new XElement("colkind", (int)sprite.SepMasks == 1 ? 1 : 0),
+            new XElement("colkind", (int)sprite.SepMasks == 0 ? 1 : 0), // if sepmasks is AxisAlignedRect (0), use Rectangle (1), otherwise default to Precise (0)			
             new XElement("coltolerance", "0"),
             new XElement("sepmasks", sprite.SepMasks.ToString("D")),
             new XElement("bboxmode", sprite.BBoxMode.ToString()),

--- a/ExportToGMS1Project.csx
+++ b/ExportToGMS1Project.csx
@@ -101,7 +101,7 @@ void ExportSprite(UndertaleSprite sprite)
             new XElement("type", "0"),
             new XElement("xorig", sprite.OriginX.ToString()),
             new XElement("yorigin", sprite.OriginY.ToString()),
-            new XElement("colkind", sprite.BBoxMode.ToString()),
+            new XElement("colkind", (int)sprite.SepMasks == 1 ? 1 : 0),
             new XElement("coltolerance", "0"),
             new XElement("sepmasks", sprite.SepMasks.ToString("D")),
             new XElement("bboxmode", sprite.BBoxMode.ToString()),


### PR DESCRIPTION
Closes #12 

Checks `sepmasks` (values [here](https://github.com/krzys-h/UndertaleModTool/blob/32b7e838d6b0fed940ce7850dc8da68257e828f7/UndertaleModLib/Models/UndertaleSprite.cs#L92)) to set `colkind`, which sets the sprite collision shape:

- If it's `0` ("AxisAlignedRect"), `colkind` is set to Rectangle (`1`), as it's known to be used for certain.
- If it's anything else, `colkind` is set to Precise (`0`)

There's no easy way to tell if the collision shape should really be Precise, Ellipse or Diamond, as UMT says they use all Precise sepmasks, but it's a safe default.

For the sake of completion here's the possible values for `colkind`:

- `0` Precise
- `1` Rectangle
- `2` Ellipses
- `3` Diamond

UMT's "RotatedRect" might mean Diamond, but during tests with GMS 1.4 I didn't see UMT use it.